### PR TITLE
README.md: fix crate name and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this line to your application's Cargo.toml:
 
 ```toml
 [dependencies]
-hsluv = "0.1.2"
+rust-hsluv = "0.1.4"
 ```
 
 ## Usage


### PR DESCRIPTION
`hsluv` appears to be a different crate